### PR TITLE
fix(android): use root project variables compileSdkVersion, minSdkVersion, targetSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,10 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('ZendeskMessaging_compileSdkVersion', 29)
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
     defaultConfig {
-        minSdkVersion safeExtGet('ZendeskMessaging_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('ZendeskMessaging_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Changed `build.gradle` variable names to standard RN names. This caused building issues, because root project version were different than in module.