### PR TITLE
iOS device token fix + getUnreadMessageCount()

### DIFF
--- a/android/src/main/java/com/robbywh/reactnativezendeskmessaging/ReactNativeZendeskMessagingModule.java
+++ b/android/src/main/java/com/robbywh/reactnativezendeskmessaging/ReactNativeZendeskMessagingModule.java
@@ -50,6 +50,16 @@ public class ReactNativeZendeskMessagingModule extends ReactContextBaseJavaModul
   }
 
   @ReactMethod
+  public void getUnreadMessageCount(Promise promise) {
+    try {
+      int unreadMsgCount = Zendesk.getInstance().getMessaging().getUnreadMessageCount();
+      promise.resolve(unreadMsgCount);
+    } catch (Exception e) {
+      promise.reject("Zendesk Error", e.getMessage());
+    }
+  }
+
+  @ReactMethod
   public void loginUser(String token, Promise promise) {
     Zendesk.getInstance().loginUser(token, new SuccessCallback<ZendeskUser>() {
       @Override

--- a/ios/ReactNativeZendeskMessaging.m
+++ b/ios/ReactNativeZendeskMessaging.m
@@ -3,6 +3,7 @@
 @interface RCT_EXTERN_MODULE(ZendeskMessaging, NSObject)
 RCT_EXTERN_METHOD(initialize: (NSString *)channelKey resolver:(RCTPromiseResolveBlock *)resolve rejecter: (RCTPromiseRejectBlock *)reject)
 RCT_EXTERN_METHOD(showMessaging)
+RCT_EXTERN_METHOD(getUnreadMessageCount: (RCTPromiseResolveBlock *)resolve rejecter:(RCTPromiseRejectBlock *)reject)
 RCT_EXTERN_METHOD(loginUser: (NSString *)token resolver:(RCTPromiseResolveBlock *)resolve rejecter: (RCTPromiseRejectBlock *)reject)
 RCT_EXTERN_METHOD(logoutUser: (RCTPromiseResolveBlock *)resolve rejecter: (RCTPromiseRejectBlock *)reject)
 RCT_EXTERN_METHOD(updatePushNotificationToken: (NSString *)deviceToken resolver:(RCTPromiseResolveBlock *)resolve rejecter: (RCTPromiseRejectBlock *)reject)

--- a/ios/ReactNativeZendeskMessaging.swift
+++ b/ios/ReactNativeZendeskMessaging.swift
@@ -20,6 +20,17 @@ class ZendeskMessaging: NSObject {
       }
     }
   }
+    
+  @objc
+  func getUnreadMessageCount(_ resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    DispatchQueue.main.async {
+        guard let messageCount = Zendesk.instance?.messaging?.getUnreadMessageCount()
+        else {
+            return reject("error", "Zendesk chat controller not available", nil)
+        }
+        resolve(messageCount)
+    }
+  }
 
   @objc
   func showMessaging() {
@@ -28,7 +39,7 @@ class ZendeskMessaging: NSObject {
         return }
       let viewController = RCTPresentedViewController();
       viewController?.present(zendeskController, animated: true) {
-        print("Messaging have shown")
+        print("Zendesk Messaging is now showing.")
       }
     }
   }

--- a/ios/ReactNativeZendeskMessaging.swift
+++ b/ios/ReactNativeZendeskMessaging.swift
@@ -60,16 +60,28 @@ class ZendeskMessaging: NSObject {
     }
   }
 
-  @objc
-  func updatePushNotificationToken(_ deviceToken:String,
-    resolver resolve: @escaping RCTPromiseResolveBlock,
-    rejecter reject: @escaping RCTPromiseRejectBlock
-  ){
-    do{
-      try PushNotifications.updatePushNotificationToken(Data(deviceToken.utf8))
-      resolve("success");
-    } catch {
-      reject("error","\(error)",nil)
+    @objc
+    func updatePushNotificationToken(_ deviceToken:String,
+      resolver resolve: @escaping RCTPromiseResolveBlock,
+      rejecter reject: @escaping RCTPromiseRejectBlock
+    ){
+        let len = deviceToken.count / 2
+        var data = Data(capacity: len)
+        var i = deviceToken.startIndex
+        for _ in 0..<len {
+          let j = deviceToken.index(i, offsetBy: 2)
+          let bytes = deviceToken[i..<j]
+          if var num = UInt8(bytes, radix: 16) {
+              data.append(&num, count: 1)
+          }
+          i = j
+        }
+      do{
+        try
+          PushNotifications.updatePushNotificationToken(data)
+          resolve("success");
+      } catch {
+          reject("error","\(error)",nil)
+      }
     }
-  }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,13 +9,13 @@ const LINKING_ERROR =
 const ZendeskMessaging = NativeModules.ZendeskMessaging
   ? NativeModules.ZendeskMessaging
   : new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
-      }
-    );
+    {},
+    {
+      get() {
+        throw new Error(LINKING_ERROR);
+      },
+    }
+  );
 
 export const initialize = async (
   channelKey: string,
@@ -32,6 +32,18 @@ export const initialize = async (
 
 export const showMessaging = () => {
   return ZendeskMessaging.showMessaging();
+};
+
+export const getUnreadMessageCount = async (
+  onSuccess?: (unreadMessageCount: number) => void,
+  onError?: (err: any) => void
+) => {
+  try {
+    const messageCount = await ZendeskMessaging.getUnreadMessageCount();
+    onSuccess && onSuccess(messageCount);
+  } catch (err: any) {
+    onError && onError(err);
+  }
 };
 
 export const loginUser = async (


### PR DESCRIPTION
### Summary
- Push notifications were not working on iOS, upon investigation, the token was incorrectly formatted and my colleague fixed token conversion such that it works now. 
- I added a function to get the unread message count following the same pattern you had set up. Usage, I presume the user has to be logged in, then:
`getUnreadMessageCount((unreadMessageCount: number) => void),
  (error: any) => void));`