### PR TITLE
Bugfix: Chat conversation click issue on iOS

### DIFF
--- a/ios/ReactNativeZendeskMessaging.swift
+++ b/ios/ReactNativeZendeskMessaging.swift
@@ -24,13 +24,18 @@ class ZendeskMessaging: NSObject {
   @objc
   func showMessaging() {
     DispatchQueue.main.async {
-      guard let zendeskController = Zendesk.instance?.messaging?.messagingViewController() else {
-        return }
-      let viewController = RCTPresentedViewController();
-      viewController?.present(zendeskController, animated: true) {
-        print("Messaging have shown")
+          guard let viewController = Zendesk.instance?.messaging?.messagingViewController(),
+                let rootController = RCTPresentedViewController() else {
+            return
+          }
+
+          if let navigationController = rootController.navigationController {
+            navigationController.pushViewController(viewController, animated: true)
+          } else {
+            let navigationController = UINavigationController(rootViewController: viewController)
+            rootController.present(navigationController, animated: true, completion: nil)
+          }
       }
-    }
   }
 
   @objc

--- a/ios/ReactNativeZendeskMessaging.swift
+++ b/ios/ReactNativeZendeskMessaging.swift
@@ -65,11 +65,22 @@ class ZendeskMessaging: NSObject {
     resolver resolve: @escaping RCTPromiseResolveBlock,
     rejecter reject: @escaping RCTPromiseRejectBlock
   ){
+      let len = deviceToken.count / 2
+      var data = Data(capacity: len)
+      var i = deviceToken.startIndex
+      for _ in 0..<len {
+        let j = deviceToken.index(i, offsetBy: 2)
+        let bytes = deviceToken[i..<j]
+        if var num = UInt8(bytes, radix: 16) { data.append(&num, count: 1) }
+        i = j
+      }
+      
     do{
-      try PushNotifications.updatePushNotificationToken(Data(deviceToken.utf8))
-      resolve("success");
+      try
+        PushNotifications.updatePushNotificationToken(data)
+        resolve("success");
     } catch {
-      reject("error","\(error)",nil)
+        reject("error","\(error)",nil)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robbywh/react-native-zendesk-messaging",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "description": "React Native Zendesk Messaging",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
**Describe the bug**
After bringing up the messaging modal, users cannot select a conversation in iOS. It works fine in Android

**To Reproduce**
Steps to reproduce the behavior:

1.  Call `showMessaging()`
2. Try selecting a conversation

**Expected behavior**
I should be able to select a conversation and continue

**Screenshots**

https://github.com/user-attachments/assets/5f2f2ea6-e9da-42b9-9c1e-ef19c39fd6c7


Platform: iOS
React Native Version 0.74.1