### PR TITLE
Update Zendesk Messaging SDK to Comply with New Google Play Policies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation "zendesk.messaging:messaging-android:2.9.0"
+  implementation "zendesk.messaging:messaging-android:2.18.0"
 }
 
 if (isNewArchitectureEnabled()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robbywh/react-native-zendesk-messaging",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": false,
   "description": "React Native Zendesk Messaging",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
This Pull Request updates the Zendesk Messaging SDK from:

```
zendesk.messaging:messaging-android:2.9.0
```

to:

```
zendesk.messaging:messaging-android:2.18.0
```

#### Reason for the Update

Google Play has introduced new privacy guidelines for Android apps that restrict the use of `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions. Apps requesting these permissions without a valid justification are now being rejected during the review process.

Version `2.9.0` of the Zendesk Messaging SDK still requests these deprecated permissions, which caused our app to be rejected by the Google Play team.

Starting from version `2.18.0`, the Zendesk SDK complies with the new requirements by using the Android Photo Picker instead of directly requesting media permissions.

#### Outcome

After upgrading to version `2.18.0`, our app successfully passed Google Play’s review and was approved for publication.
